### PR TITLE
Repositories should be an array of objects | spotfix

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ For PHPCS to function appropriately, it needs to be included in the repository v
 **Within `repositories`, add the following:**
 
 ```
-"repositories": {
+"repositories": [
     {
       "name": "moderntribe/TribalScents",
       "type": "github",
       "url": "https://github.com/moderntribe/TribalScents",
       "no-api": true
     }
-}
+]
 ```
 
 ### Create `phpcs.xml`


### PR DESCRIPTION
Per the [composer.json schema definition](https://getcomposer.org/doc/04-schema.md#repositories) we want `"repositories"` to be an array of objects :-)